### PR TITLE
Priya: Log handler response code and request.

### DIFF
--- a/journal/journal.go
+++ b/journal/journal.go
@@ -68,6 +68,11 @@ func LogRequest(r *http.Request) {
 	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.String(), "headers", r.Header, "ts", time.Now())
 }
 
+// LogResponseFromHandler logs details of an HTTP request with response code from Handler.
+func LogResponseFromHandler(r *http.Request, responseCode int) {
+	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.String(), "responseCode", responseCode, "headers", r.Header, "ts", time.Now())
+}
+
 // LogRequestUUID logs details of an HTTP request with a UUID.
 func LogRequestUUID(r *http.Request, UUID string) {
 	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.String(), "headers", r.Header, "ts", time.Now(), "UUID", UUID)


### PR DESCRIPTION
In the mid tier logging, it makes it easier for services to log the handler state i.e request and the response code for the request. 

See https://github.com/EconomistDigitalSolutions/mt-content-blogs/commit/f7841a447f5402d6091dfd3842d48bda34203a0f shows how we do that. We have a wrapper over ResponseWriter as the default http.ResponseWriter doesn't expose the status. 

In order to reuse most of the watchman code. I've put in a utility logger for the hander. This is something that will certainly be useful for the other mid tier services. 
