### PR TITLE
Priya: URL.String() outputs json, what we really need is URL.Path

### DIFF
--- a/journal/journal.go
+++ b/journal/journal.go
@@ -65,18 +65,18 @@ func GetLogFile(logFile, fallback string) (string, error) {
 
 // LogRequest logs details of an HTTP request.
 func LogRequest(r *http.Request) {
-	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.String(), "headers", r.Header, "ts", time.Now())
+	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.Path, "headers", r.Header, "ts", time.Now())
 }
 
 // LogRequestWithInfo logs request data to the reqyest channel, but allows some extra info to be passed along
 func LogRequestWithInfo(r *http.Request, infoPairs ...interface{}) {
-	keyVals := append([]interface{}{"channel", "request", "service", Service, "method", r.Method, "url", r.URL.String(), "headers", r.Header, "ts", time.Now()}, infoPairs...)
+	keyVals := append([]interface{}{"channel", "request", "service", Service, "method", r.Method, "url", r.URL.Path, "headers", r.Header, "ts", time.Now()}, infoPairs...)
 	logger.Log(keyVals...)
 }
 
 // LogRequestUUID logs details of an HTTP request with a UUID.
 func LogRequestUUID(r *http.Request, UUID string) {
-	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.String(), "headers", r.Header, "ts", time.Now(), "UUID", UUID)
+	logger.Log("channel", "request", "service", Service, "method", r.Method, "url", r.URL.Path, "headers", r.Header, "ts", time.Now(), "UUID", UUID)
 }
 
 // LogChannel logs data to a log channel.


### PR DESCRIPTION
This fixes an issue on the logs where url appears as

url: {"Scheme":"","Opaque":"","User":null,"Host":"","Path":"/healthcheck","RawPath":"","RawQuery":"","Fragment":""}

instead what we really require was url.Path
